### PR TITLE
Update the information reduction computation

### DIFF
--- a/gaussianisation.py
+++ b/gaussianisation.py
@@ -175,6 +175,6 @@ class HistogramGaussianisation:
         log_pZ += ibijector.gradient(Z_U)
         transformations.append(ibijector)
 
-        MI = information_reduction(Z_G,Z)
+        MI = information_reduction(Z,Z_G)
 
         return Z_G, transformations, log_pZ, MI


### PR DESCRIPTION
I switched the order of Z and Z_G. The MI computation should be done in the orthoconv layer, but I put it here for convenience, this is why it has to be computed in reverse order. We could do it in the orthoconv layer, but we still need to have the discussion about doing the reasoning behind doing the marginal gaussianization only on the channel dimension (B*H*W, C)  instead of in each feature independently (B, H*W*C).